### PR TITLE
Added Polly and Orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# SonarQube
+.sonarqube/
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/CleanArchitectureExample.Application/Events/EventDispatcher.cs
+++ b/CleanArchitectureExample.Application/Events/EventDispatcher.cs
@@ -1,11 +1,20 @@
 ﻿using CleanArchitectureExample.Domain.Interfaces.Events;
 using MediatR;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace CleanArchitectureExample.Application.Events
 {
     public class EventDispatcher : IEventDispatcher
     {
+        private readonly IMediator _mediator;
+
+        public EventDispatcher(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+
         private List<INotification> AfterCommitEvents { get; set; } = new List<INotification>();
         private List<INotification> PreCommitEvents { get; set; } = new List<INotification>();
 
@@ -21,7 +30,21 @@ namespace CleanArchitectureExample.Application.Events
 
         }
 
+        public async Task FireAfterCommitEvents()
+        {
+            AfterCommitEvents.ForEach(async x =>
+            {
+                await _mediator.Publish(x);
+            });
+        }
 
+        public async Task FirePreCommitEvents()
+        {
+            PreCommitEvents.ForEach(async x =>
+            {
+                await _mediator.Publish(x);
+            });
+        }
 
         public List<INotification> GetAfterCommitEvents()
         {

--- a/CleanArchitectureExample.Application/Orchestration/IOrquestrator.cs
+++ b/CleanArchitectureExample.Application/Orchestration/IOrquestrator.cs
@@ -1,0 +1,14 @@
+﻿using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CleanArchitectureExample.Application.Orchestration
+{
+    public interface IOrquestrator
+    {
+        Task<RequestResult> SendCommand<T>(IRequest<T> request);
+        Task<RequestResult> SendQuery<T>(IRequest<T> request);
+    }
+}

--- a/CleanArchitectureExample.Application/Orchestration/Orchestrator.cs
+++ b/CleanArchitectureExample.Application/Orchestration/Orchestrator.cs
@@ -1,0 +1,90 @@
+﻿using CleanArchitectureExample.Domain.Core.DomainNotification;
+using CleanArchitectureExample.Domain.Interfaces.Events;
+using CleanArchitectureExample.Domain.Interfaces.Persistence.UnitOfWork;
+using MediatR;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CleanArchitectureExample.Application.Orchestration
+{
+    public class Orchestrator : IOrquestrator
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IDomainNotifications _domainNotifications;
+        private readonly IEventDispatcher _eventDispatcher;
+        protected readonly IMediator _mediator;
+
+        public Orchestrator(IUnitOfWork unitOfWork, IDomainNotifications domainNotifications, IEventDispatcher eventDispatcher, IMediator mediator)
+        {
+            _unitOfWork = unitOfWork;
+            _domainNotifications = domainNotifications;
+            _eventDispatcher = eventDispatcher;
+            _mediator = mediator;
+        }
+
+        public async Task<RequestResult> SendCommand<T>(IRequest<T> request)
+        {
+            var commandResponse = await _mediator.Send(request);
+
+            // Fire pre post events
+            await _eventDispatcher.FirePreCommitEvents();
+
+            if (_domainNotifications.HasNotifications())
+            {
+                return new RequestResult
+                {
+                    Success = false,
+                    Messages = _domainNotifications.GetAll()
+                };
+            }
+            else
+            {
+                if (await _unitOfWork.Commit())
+                {
+                    // Fire after commit events
+                    await _eventDispatcher.FireAfterCommitEvents();
+
+                    return new RequestResult
+                    {
+                        Success = true,
+                        Data = commandResponse
+                    };
+                }
+                else
+                {
+                    return new RequestResult
+                    {
+                        Success = false,
+                        Messages = new List<string>()
+                        {
+                            "An error ocurred while saving data"
+                        }
+                    };
+                }
+            }
+
+        }
+
+        public async Task<RequestResult> SendQuery<T>(IRequest<T> request)
+        {
+            var commandResponse = await _mediator.Send(request);
+
+            if (_domainNotifications.HasNotifications())
+            {
+                return new RequestResult
+                {
+                    Success = false,
+                    Messages = _domainNotifications.GetAll()
+                };
+            }
+            else
+            {
+                return new RequestResult
+                {
+                    Success = true,
+                    Data = commandResponse
+                };
+            }
+        }
+    }
+}

--- a/CleanArchitectureExample.Application/Orchestration/RequestResult.cs
+++ b/CleanArchitectureExample.Application/Orchestration/RequestResult.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CleanArchitectureExample.Application.Orchestration
+{
+    public class RequestResult
+    {
+        public bool Success { get; set; }
+        public List<string> Messages { get; set; } = new List<string>();
+        public object Data { get; set; }
+    }
+}

--- a/CleanArchitectureExample.CrossCutting/IoCContainer.cs
+++ b/CleanArchitectureExample.CrossCutting/IoCContainer.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using CleanArchitectureExample.Application.DomainNotifications;
 using CleanArchitectureExample.Application.Events;
+using CleanArchitectureExample.Application.Orchestration;
 using CleanArchitectureExample.Domain.Core.DomainNotification;
 using CleanArchitectureExample.Domain.Interfaces.Events;
 using CleanArchitectureExample.Domain.Interfaces.Persistence.Repositories;
@@ -23,7 +24,7 @@ namespace CleanArchitectureExample.CrossCutting
     {
         public static void InitializeContainer(IServiceCollection services)
         {
-            string connectionString = "Data Source=localhost;Initial Catalog=CleanArchitectureExample;Persist Security Info=False;User ID=your_user;Password=your_password;";
+            string connectionString = "Data Source=localhost;Initial Catalog=CleanArchitectureExample;Persist Security Info=False;User ID=sa;Password=123456;";
 
             //Inject external tools
             services.AddAutoMapper(AppDomain.CurrentDomain.Load("CleanArchitectureExample.Domain"));
@@ -35,6 +36,7 @@ namespace CleanArchitectureExample.CrossCutting
 
 
             //Inject internal work classes
+            services.AddScoped<IOrquestrator, Orchestrator>();
             services.AddScoped<IUnitOfWork, UnitOfWork>();
             services.AddScoped<IDomainNotifications, DomainNotifications>();
             services.AddSingleton<IContainer, HttpContextServiceProviderProxy>();

--- a/CleanArchitectureExample.Domain/Interfaces/Events/IEventDispatcher.cs
+++ b/CleanArchitectureExample.Domain/Interfaces/Events/IEventDispatcher.cs
@@ -2,18 +2,21 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace CleanArchitectureExample.Domain.Interfaces.Events
 {
     public interface IEventDispatcher
     {
-        List<INotification> GetAfterCommitEvents();
-        void AddAfterCommitEvent(INotification evt);
-        void RemoveAfterCommitEvent(INotification evt);
-
-
         List<INotification> GetPreCommitEvents();
         void AddPreCommitEvent(INotification evt);
         void RemovePreCommitEvent(INotification evt);
+        Task FirePreCommitEvents();
+
+
+        List<INotification> GetAfterCommitEvents();
+        void AddAfterCommitEvent(INotification evt);
+        void RemoveAfterCommitEvent(INotification evt);
+        Task FireAfterCommitEvents();
     }
 }

--- a/CleanArchitectureExample.Domain/RequestHandlers/BookLoanHandlers/Commands/RequestLoan/Events/LoanEffetivatedEventSendMail.cs
+++ b/CleanArchitectureExample.Domain/RequestHandlers/BookLoanHandlers/Commands/RequestLoan/Events/LoanEffetivatedEventSendMail.cs
@@ -17,7 +17,7 @@ namespace CleanArchitectureExample.Domain.RequestHandlers.BookLoanHandlers.Comma
 
         async Task INotificationHandler<LoanEffetivatedEvent>.Handle(LoanEffetivatedEvent notification, CancellationToken cancellationToken)
         {
-            _emailServices.SendEmail(new List<string> { notification.Email }, "Book loan", $"Book {notification.BookName} lent, expected return date {notification.ReturnDate.ToShortDateString()}");            
+            await _emailServices.SendEmail(new List<string> { notification.Email }, "Book loan", $"Book {notification.BookName} lent, expected return date {notification.ReturnDate.ToShortDateString()}");            
         }
     }
 }

--- a/CleanArchitectureExample.Domain/RequestHandlers/BookLoanHandlers/Commands/RequestLoan/Events/LoanEffetivatedEventSendSms.cs
+++ b/CleanArchitectureExample.Domain/RequestHandlers/BookLoanHandlers/Commands/RequestLoan/Events/LoanEffetivatedEventSendSms.cs
@@ -17,7 +17,7 @@ namespace CleanArchitectureExample.Domain.RequestHandlers.BookLoanHandlers.Comma
 
         async Task INotificationHandler<LoanEffetivatedEvent>.Handle(LoanEffetivatedEvent notification, CancellationToken cancellationToken)
         {
-            _smsServices.SendSms(notification.Phone,  $"Book {notification.BookName} lent, expected return date {notification.ReturnDate.ToShortDateString()}");
+            await _smsServices.SendSms(notification.Phone,  $"Book {notification.BookName} lent, expected return date {notification.ReturnDate.ToShortDateString()}");
         }
     }
 }

--- a/CleanArchitectureExample.Persistence.UnitOfWork/Class1.cs
+++ b/CleanArchitectureExample.Persistence.UnitOfWork/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace CleanArchitectureExample.Persistence.UnitOfWork
+{
+    public class Class1
+    {
+    }
+}

--- a/CleanArchitectureExample.Persistence.UnitOfWork/CleanArchitectureExample.Persistence.UnitOfWork.csproj
+++ b/CleanArchitectureExample.Persistence.UnitOfWork/CleanArchitectureExample.Persistence.UnitOfWork.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/CleanArchitectureExample.Service/CleanArchitectureExample.Service.csproj
+++ b/CleanArchitectureExample.Service/CleanArchitectureExample.Service.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Polly" Version="7.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CleanArchitectureExample.Application\CleanArchitectureExample.Application.csproj" />
   </ItemGroup>
 

--- a/CleanArchitectureExample.Service/Communication/EmailServices.cs
+++ b/CleanArchitectureExample.Service/Communication/EmailServices.cs
@@ -1,14 +1,38 @@
 ﻿using CleanArchitectureExample.Domain.Interfaces.Services.Communication;
+using Polly;
+using Polly.Retry;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CleanArchitectureExample.Service.Communication
 {
     public class EmailServices : IEmailServices
     {
+        private AsyncRetryPolicy retryPolice;
+
+        public EmailServices()
+        {
+            retryPolice = Policy.Handle<TimeoutException>().WaitAndRetryAsync(5, i => TimeSpan.FromMilliseconds(500));
+        }
+
         public async Task SendEmail(List<string> recipient, string subject, string message)
         {
-            //SendEmail
+            var rand = 0;
+            await retryPolice.ExecuteAsync(async () =>
+            {
+                Console.WriteLine("Trying to send email");
+                // Force exception for demo purpose
+                if (rand <=2)
+                {
+                    rand++;
+                    throw new TimeoutException();
+                }
+                    
+                await Task.Delay(1000);
+                Console.WriteLine("Email Sent");
+            });
         }
     }
 }

--- a/CleanArchitectureExample.Service/Communication/SmsServices.cs
+++ b/CleanArchitectureExample.Service/Communication/SmsServices.cs
@@ -1,13 +1,27 @@
-﻿using CleanArchitectureExample.Domain.Interfaces.Services.Communication;
+﻿using CleanArchitectureExample.Domain.Interfaces.Events;
+using CleanArchitectureExample.Domain.Interfaces.Services.Communication;
+using MediatR;
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CleanArchitectureExample.Service.Communication
 {
     public class SmsServices : ISmsServices
     {
+        private readonly IEventDispatcher _eventDispatcher;
+
+        public SmsServices(IEventDispatcher eventDispatcher)
+        {
+            this._eventDispatcher = eventDispatcher;
+        }
+
         public async Task SendSms(string phoneNumber, string text)
         {
-            //Send SMS
+            await Task.Delay(1000);
+            Console.WriteLine("SMS Sent");
+            //SMS sent
+
         }
     }
 }

--- a/CleanArchitectureExample.WebAPI/Controllers/AuthorController.cs
+++ b/CleanArchitectureExample.WebAPI/Controllers/AuthorController.cs
@@ -1,4 +1,5 @@
-﻿using CleanArchitectureExample.Domain.Core.DomainNotification;
+﻿using CleanArchitectureExample.Application.Orchestration;
+using CleanArchitectureExample.Domain.Core.DomainNotification;
 using CleanArchitectureExample.Domain.Interfaces.Events;
 using CleanArchitectureExample.Domain.Interfaces.Persistence.UnitOfWork;
 using CleanArchitectureExample.Domain.RequestHandlers.AuthorsHandlers.Commands.AddAuthor;
@@ -12,19 +13,19 @@ namespace CleanArchitectureExample.WebAPI.Controllers
     [ApiController]
     public class AuthorController : BaseController
     {
-        public AuthorController(IUnitOfWork unitOfWork,
-            IDomainNotifications domainNotifications,
-            IEventDispatcher eventDispatcher,
-            IMediator mediator) : base(unitOfWork, domainNotifications, eventDispatcher, mediator)
+        private readonly IOrquestrator _orquestrator;
+
+        public AuthorController(IOrquestrator orquestrator)
         {
+            _orquestrator = orquestrator;
         }
 
         [HttpPost]
         [Route("Add/v1")]
         public async Task<IActionResult> AddAuthor(AddAuthorCommand command)
         {
-            var result = await _mediator.Send(command);
-            return await ReturnCommand(result);
+            RequestResult requestResult = await _orquestrator.SendCommand(command);
+            return await ReturnRequestResult(requestResult);
         }
     }
 }

--- a/CleanArchitectureExample.WebAPI/Controllers/BookController.cs
+++ b/CleanArchitectureExample.WebAPI/Controllers/BookController.cs
@@ -1,4 +1,5 @@
-﻿using CleanArchitectureExample.Domain.Core.DomainNotification;
+﻿using CleanArchitectureExample.Application.Orchestration;
+using CleanArchitectureExample.Domain.Core.DomainNotification;
 using CleanArchitectureExample.Domain.Interfaces.Events;
 using CleanArchitectureExample.Domain.Interfaces.Persistence.UnitOfWork;
 using CleanArchitectureExample.Domain.RequestHandlers.BookHandlers.Commands.AddBook;
@@ -12,19 +13,19 @@ namespace CleanArchitectureExample.WebAPI.Controllers
     [ApiController]
     public class BookController : BaseController
     {
-        public BookController(IUnitOfWork unitOfWork,
-            IDomainNotifications domainNotifications,
-            IEventDispatcher eventDispatcher,
-            IMediator mediator) : base(unitOfWork, domainNotifications, eventDispatcher, mediator)
+        private readonly IOrquestrator _orquestrator;
+
+        public BookController(IOrquestrator orquestrator)
         {
+            _orquestrator = orquestrator;
         }
 
         [Route("Add/v1")]
         [HttpPost]
         public async Task<IActionResult> AddBook(AddBookCommand command)
         {
-            AddBookCommandResponseViewModel result = await _mediator.Send(command);
-            return await ReturnCommand(result);
+            RequestResult requestResult = await _orquestrator.SendCommand(command);
+            return await ReturnRequestResult(requestResult);
         }
     }
 }

--- a/CleanArchitectureExample.WebAPI/Controllers/BookLoanController.cs
+++ b/CleanArchitectureExample.WebAPI/Controllers/BookLoanController.cs
@@ -1,4 +1,5 @@
-﻿using CleanArchitectureExample.Domain.Core.DomainNotification;
+﻿using CleanArchitectureExample.Application.Orchestration;
+using CleanArchitectureExample.Domain.Core.DomainNotification;
 using CleanArchitectureExample.Domain.Interfaces.Events;
 using CleanArchitectureExample.Domain.Interfaces.Persistence.UnitOfWork;
 using CleanArchitectureExample.Domain.RequestHandlers.BookLoanHandlers.Commands.RequestLoan;
@@ -14,35 +15,35 @@ namespace CleanArchitectureExample.WebAPI.Controllers
     [ApiController]
     public class BookLoanController : BaseController
     {
-        public BookLoanController(IUnitOfWork unitOfWork,
-            IDomainNotifications domainNotifications,
-            IEventDispatcher eventDispatcher,
-            IMediator mediator) : base(unitOfWork, domainNotifications, eventDispatcher, mediator)
+        private readonly IOrquestrator _orquestrator;
+
+        public BookLoanController(IOrquestrator orquestrator)
         {
+            _orquestrator = orquestrator;
         }
 
         [HttpPost]
         [Route("RequestLoan/v1")]
         public async Task<IActionResult> Loan(RequestLoanCommand command)
         {
-            var result = await _mediator.Send(command, new System.Threading.CancellationToken());
-            return await ReturnCommand(result);
+            RequestResult requestResult = await _orquestrator.SendCommand(command);
+            return await ReturnRequestResult(requestResult);
         }
 
         [HttpPost]
         [Route("ReturnBook/v1")]
         public async Task<IActionResult> ReturnBook(ReturnBookCommand command)
         {
-            var result = await _mediator.Send(command, new System.Threading.CancellationToken());
-            return await ReturnCommand(result);
+            RequestResult requestResult = await _orquestrator.SendCommand(command);
+            return await ReturnRequestResult(requestResult);
         }
 
         [HttpGet]
         [Route("GetAll/v1")]
         public async Task<IActionResult> GetAllLoans(BookLoanGetAllQuery query)
         {
-            var result = await _mediator.Send(query, new System.Threading.CancellationToken());
-            return ReturnQuery(result);
+            RequestResult requestResult = await _orquestrator.SendQuery(query);
+            return await ReturnRequestResult(requestResult);
         }
     }
 }

--- a/CleanArchitectureExample.WebAPI/Controllers/PersonController.cs
+++ b/CleanArchitectureExample.WebAPI/Controllers/PersonController.cs
@@ -1,4 +1,5 @@
-﻿using CleanArchitectureExample.Domain.Core.DomainNotification;
+﻿using CleanArchitectureExample.Application.Orchestration;
+using CleanArchitectureExample.Domain.Core.DomainNotification;
 using CleanArchitectureExample.Domain.Interfaces.Events;
 using CleanArchitectureExample.Domain.Interfaces.Persistence.UnitOfWork;
 using CleanArchitectureExample.Domain.RequestHandlers.PersonHandlers.Commands.AddPerson;
@@ -13,27 +14,27 @@ namespace CleanArchitectureExample.WebAPI.Controllers
     [ApiController]
     public class PersonController : BaseController
     {
-        public PersonController(IUnitOfWork unitOfWork,
-            IDomainNotifications domainNotifications,
-            IEventDispatcher eventDispatcher,
-            IMediator mediator) : base(unitOfWork, domainNotifications, eventDispatcher, mediator)
+        private readonly IOrquestrator _orquestrator;
+
+        public PersonController(IOrquestrator orquestrator)
         {
+            _orquestrator = orquestrator;
         }
 
         [Route("Add/v1")]
         [HttpPost]
         public async Task<IActionResult> AddPerson(AddPersonCommand command)
         {
-            var result = await _mediator.Send(command);
-            return await ReturnCommand(result);
+            RequestResult requestResult = await _orquestrator.SendCommand(command);
+            return await ReturnRequestResult(requestResult);
         }
 
         [Route("GetAll/v1")]
         [HttpGet]
         public async Task<IActionResult> GetAll(GetAllPeopleQuery query)
         {
-            var result = await _mediator.Send(query);
-            return ReturnQuery(result);
+            var result = await _orquestrator.SendQuery(query);
+            return await ReturnRequestResult(result);
         }
     }
 }

--- a/CleanArchitectureExample.WebAPI/Startup.cs
+++ b/CleanArchitectureExample.WebAPI/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
 using System;
 
 namespace CleanArchitectureExample.WebAPI
@@ -22,7 +23,7 @@ namespace CleanArchitectureExample.WebAPI
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(config => config.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore);
             services.AddHttpContextAccessor();
             IoCContainer.InitializeContainer(services);
         }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ###
 ##### For example purpose, a cataloging system for books and loans was created in a very basic way
 ##
-### In this project were apllied the concepts of:
+### In this project were applied the concepts of:
 - ##### DDD
 - ##### CleanCode
 - ##### Domain Notifications
@@ -18,10 +18,11 @@
 - ##### Entify Framework (EF Core)
 - ##### MediatR
 - ##### Fluent Assertions
+- ##### Polly
 - ##### XUnit
 - ##### Moq.
 - ##### Moq.AutoMock
 ##
 #####  Feel free to use it or modify it as you wish.
 ##### Be careful when using it in a production environment
-##### Suggestions for improvements are very welcome and if you found a bugs or have any question just open an Issue and I'll take a look as soon as possible =)
+##### Suggestions for improvements are very welcome and if you find any bugs or have any questions just open an Issue and I'll take a look as soon as possible =)


### PR DESCRIPTION
Added Polly and Orchestrator

Added Polly example in SendEmail method at EmailServices.cs. For example purposes, an exception is generated to demonstrate the Polly workflow handling errors.

All commit logic were removed from BaseController and migrated to Orchestrator class inside Application layer, this way, it will be a lot easier to attach other front-end type to the solution and it fits better in the concept of hexagonal architecture

Fixed typos in Readme.md